### PR TITLE
Update Dockerfile.ntopng

### DIFF
--- a/Dockerfile.ntopng
+++ b/Dockerfile.ntopng
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 MAINTAINER ntop.org
 
 RUN apt-get update && \


### PR DESCRIPTION
Use Ubuntu18.04 in some times can't run redis successfully, ubuntu20.04 can do it batter.