### PR TITLE
Added arm64 Debian Dockerfile for Raspberry Pi 4

### DIFF
--- a/Dockerfile.ntopng-arm64
+++ b/Dockerfile.ntopng-arm64
@@ -1,0 +1,19 @@
+FROM debian:buster
+
+RUN apt-get update && \
+    apt-get -y -q install software-properties-common wget lsb-release gnupg redis-server && \
+    add-apt-repository contrib && \
+    wget -q https://packages.ntop.org/apt-stable/buster/all/apt-ntop-stable.deb && \
+    apt install ./apt-ntop-stable.deb
+
+RUN apt-get clean all && \
+    apt-get update && \
+    apt-get -y install ntopng-data=3.8+dfsg1-2.1 -V && \
+    apt-get -y install ntopng
+
+RUN echo '#!/bin/bash\n/etc/init.d/redis-server start\nntopng "$@"' > /run.sh && \
+    chmod +x /run.sh
+
+EXPOSE 3000
+
+ENTRYPOINT ["/run.sh"]


### PR DESCRIPTION
The original `Dockerfile.ntopng-raspberry` cannot be built on Raspberry 4 (arm64v8) due to missing dependencies and versions mismatch.
I have created a new `Dockerfile.ntopng-arm64` correcting these issues:
- missing redis-server in debian:buster
- adding "contrib" repository to `/etc/apt/sources.list`
- using standard Debian stable package (which is unfortunately version `3.8.190204` only)
- installing `ntopng-data` hard coded version `3.8+dfsg1-2.1`, as the `ntopng` linked latest `4.2.210629` wouldn't work

This was the only way to make it work.

Is there any timeline for ntopng `4.3` for arm64v8 in Debian (or Ubuntu) repo?