### PR TITLE
Bump arm64 Debian Dockerfile to use latest armhf if available

### DIFF
--- a/Dockerfile.ntopng-arm64
+++ b/Dockerfile.ntopng-arm64
@@ -1,15 +1,18 @@
 FROM debian:buster
 
-RUN apt-get update && \
-    apt-get -y -q install software-properties-common wget lsb-release gnupg redis-server && \
-    add-apt-repository contrib && \
-    wget -q https://packages.ntop.org/apt-stable/buster/all/apt-ntop-stable.deb && \
-    apt install ./apt-ntop-stable.deb
+# Main dependencies and ntop.org apt package repo installation
+RUN apt update && \
+    apt -y -q install software-properties-common wget lsb-release gnupg && \
+    wget -q http://packages.ntop.org/RaspberryPI/apt-ntop_1.0.190416-469_all.deb && \
+    apt -y -q install ./apt-ntop_1.0.190416-469_all.deb
 
-RUN apt-get clean all && \
-    apt-get update && \
-    apt-get -y install ntopng-data=3.8+dfsg1-2.1 -V && \
-    apt-get -y install ntopng
+# ntopng, some of its dependencies and libcap2 / libzstd1 need to be armhf
+# architecture, because latest ntopng (4.3) is not available in arm64
+RUN apt clean all && \
+    dpkg --add-architecture armhf && \
+    apt update && \
+    apt -y -q install ntopng:armhf libcap2:armhf libzstd1:armhf
+    
 
 RUN echo '#!/bin/bash\n/etc/init.d/redis-server start\nntopng "$@"' > /run.sh && \
     chmod +x /run.sh


### PR DESCRIPTION
I've modified the `arm64` `Dockerfile`, so instead of relying directly on the latest `arm64` versions in the official Debian and/or ntop.org repository from https://packages.ntop.org/apt-stable/buster/all/, it adds the Raspberry Pi http://packages.ntop.org/RaspberryPI/ repository and then adds `armhf` architecture to Debian's `dpkg` package tool, so it installs `armhf` versions where available.

**ntopng**
- the latest `arm64` version is only `3.8.190204`
- the latest `armhf` version is `4.3.210711`

**ntopng-data**
- the latest `arm64` version is `4.2.210629`, but ntopng 3.8 requires `3.8+dfsg1-2.1`
- the latest `armhf` version is `4.3.210629`

Using latest versions (available only in `armhf`) needed few modifications:
- `armhf` architecture needs to be added to apt package manager as possible source, otherwise ntopng won't install (not available in `all` repository for Raspberry Pi)
- `ntopng` needs to be forced to install with `armhf` specified, otherwise it looks for `arm64` which is not available
- it then installs its dependencies as `armhf` also, if required (as `dpkg` recognises additional architecture)
- `libcap2:armhf` and `libzstd1:armhf` were missing in dependencies, but required, so they're installed manually