### PR TITLE
feature(docker): enable (alternative) use of env var for runtime config

### DIFF
--- a/Dockerfile.cento
+++ b/Dockerfile.cento
@@ -10,7 +10,7 @@ RUN apt-get update && \
 RUN apt-get update && \
     apt-get -y install cento
 
-RUN echo '#!/bin/bash\ncento "$@ $NTOP_CONFIG"' > /run.sh && \
+RUN echo '#!/bin/bash\ncento "$@" "$NTOP_CONFIG"' > /run.sh && \
     chmod +x /run.sh
 
 ENTRYPOINT ["/run.sh"]

--- a/Dockerfile.cento
+++ b/Dockerfile.cento
@@ -10,7 +10,7 @@ RUN apt-get update && \
 RUN apt-get update && \
     apt-get -y install cento
 
-RUN echo '#!/bin/bash\ncento "$@"' > /run.sh && \
+RUN echo '#!/bin/bash\ncento "$@ $NTOP_CONFIG"' > /run.sh && \
     chmod +x /run.sh
 
 ENTRYPOINT ["/run.sh"]

--- a/Dockerfile.n2disk
+++ b/Dockerfile.n2disk
@@ -10,7 +10,7 @@ RUN apt-get update && \
 RUN apt-get update && \
     apt-get -y install n2disk 
 
-RUN echo '#!/bin/bash\nn2disk "$@ $NTOP_CONFIG"' > /run.sh && \
+RUN echo '#!/bin/bash\nn2disk "$@" "$NTOP_CONFIG"' > /run.sh && \
     chmod +x /run.sh
 
 ENTRYPOINT ["/run.sh"]

--- a/Dockerfile.n2disk
+++ b/Dockerfile.n2disk
@@ -10,7 +10,7 @@ RUN apt-get update && \
 RUN apt-get update && \
     apt-get -y install n2disk 
 
-RUN echo '#!/bin/bash\nn2disk "$@"' > /run.sh && \
+RUN echo '#!/bin/bash\nn2disk "$@ $NTOP_CONFIG"' > /run.sh && \
     chmod +x /run.sh
 
 ENTRYPOINT ["/run.sh"]

--- a/Dockerfile.nprobe
+++ b/Dockerfile.nprobe
@@ -10,7 +10,7 @@ RUN apt-get update && \
 RUN apt-get update && \
     apt-get -y install nprobe
 
-RUN echo '#!/bin/bash\nnprobe "$@"' > /run.sh && \
+RUN echo '#!/bin/bash\nnprobe "$@ $NTOP_CONFIG"' > /run.sh && \
     chmod +x /run.sh
 
 ENTRYPOINT ["/run.sh"]

--- a/Dockerfile.nprobe
+++ b/Dockerfile.nprobe
@@ -10,7 +10,7 @@ RUN apt-get update && \
 RUN apt-get update && \
     apt-get -y install nprobe
 
-RUN echo '#!/bin/bash\nnprobe "$@ $NTOP_CONFIG"' > /run.sh && \
+RUN echo '#!/bin/bash\nnprobe "$@" "$NTOP_CONFIG"' > /run.sh && \
     chmod +x /run.sh
 
 ENTRYPOINT ["/run.sh"]

--- a/Dockerfile.nscrub
+++ b/Dockerfile.nscrub
@@ -10,7 +10,7 @@ RUN apt-get update && \
 RUN apt-get update && \
     apt-get -y install nscrub 
 
-RUN echo '#!/bin/bash\nnscrub "$@ $NTOP_CONFIG"' > /run.sh && \
+RUN echo '#!/bin/bash\nnscrub "$@" "$NTOP_CONFIG"' > /run.sh && \
     chmod +x /run.sh
 
 EXPOSE 8880

--- a/Dockerfile.nscrub
+++ b/Dockerfile.nscrub
@@ -10,7 +10,7 @@ RUN apt-get update && \
 RUN apt-get update && \
     apt-get -y install nscrub 
 
-RUN echo '#!/bin/bash\nnscrub "$@"' > /run.sh && \
+RUN echo '#!/bin/bash\nnscrub "$@ $NTOP_CONFIG"' > /run.sh && \
     chmod +x /run.sh
 
 EXPOSE 8880

--- a/Dockerfile.ntopng
+++ b/Dockerfile.ntopng
@@ -13,7 +13,7 @@ RUN apt-get update && \
 RUN apt-get update && \
     apt-get -y install ntopng ntopng-data
 
-RUN echo '#!/bin/bash\n/etc/init.d/redis-server start\nntopng "$@ $NTOP_CONFIG"' > /run.sh && \
+RUN echo '#!/bin/bash\n/etc/init.d/redis-server start\nntopng "$@" "$NTOP_CONFIG"' > /run.sh && \
     chmod +x /run.sh
 
 EXPOSE 3000

--- a/Dockerfile.ntopng
+++ b/Dockerfile.ntopng
@@ -13,7 +13,7 @@ RUN apt-get update && \
 RUN apt-get update && \
     apt-get -y install ntopng ntopng-data
 
-RUN echo '#!/bin/bash\n/etc/init.d/redis-server start\nntopng "$@"' > /run.sh && \
+RUN echo '#!/bin/bash\n/etc/init.d/redis-server start\nntopng "$@ $NTOP_CONFIG"' > /run.sh && \
     chmod +x /run.sh
 
 EXPOSE 3000

--- a/Dockerfile.ntopng-arm64
+++ b/Dockerfile.ntopng-arm64
@@ -14,7 +14,7 @@ RUN apt-get clean all && \
     apt-get -y -q install ntopng:armhf libcap2:armhf libzstd1:armhf
     
 
-RUN echo '#!/bin/bash\n/etc/init.d/redis-server start\nntopng "$@ $NTOP_CONFIG"' > /run.sh && \
+RUN echo '#!/bin/bash\n/etc/init.d/redis-server start\nntopng "$@" "$NTOP_CONFIG"' > /run.sh && \
     chmod +x /run.sh
 
 EXPOSE 3000

--- a/Dockerfile.ntopng-arm64
+++ b/Dockerfile.ntopng-arm64
@@ -14,7 +14,7 @@ RUN apt-get clean all && \
     apt-get -y -q install ntopng:armhf libcap2:armhf libzstd1:armhf
     
 
-RUN echo '#!/bin/bash\n/etc/init.d/redis-server start\nntopng "$@"' > /run.sh && \
+RUN echo '#!/bin/bash\n/etc/init.d/redis-server start\nntopng "$@ $NTOP_CONFIG"' > /run.sh && \
     chmod +x /run.sh
 
 EXPOSE 3000

--- a/Dockerfile.ntopng.dev
+++ b/Dockerfile.ntopng.dev
@@ -10,7 +10,7 @@ RUN apt-get update && \
 RUN apt-get update && \
     apt-get -y install ntopng ntopng-data
 
-RUN echo '#!/bin/bash\n/etc/init.d/redis-server start\nntopng "$@"' > /run.sh && \
+RUN echo '#!/bin/bash\n/etc/init.d/redis-server start\nntopng "$@ $NTOP_CONFIG"' > /run.sh && \
     chmod +x /run.sh
 
 EXPOSE 3000

--- a/Dockerfile.ntopng.dev
+++ b/Dockerfile.ntopng.dev
@@ -10,7 +10,7 @@ RUN apt-get update && \
 RUN apt-get update && \
     apt-get -y install ntopng ntopng-data
 
-RUN echo '#!/bin/bash\n/etc/init.d/redis-server start\nntopng "$@ $NTOP_CONFIG"' > /run.sh && \
+RUN echo '#!/bin/bash\n/etc/init.d/redis-server start\nntopng "$@" "$NTOP_CONFIG"' > /run.sh && \
     chmod +x /run.sh
 
 EXPOSE 3000

--- a/Dockerfile.pfring
+++ b/Dockerfile.pfring
@@ -10,7 +10,7 @@ RUN apt-get update && \
 RUN apt-get update && \
     apt-get -y install pfring
 
-RUN echo '#!/bin/bash\nset -e\nexec "$@ $NTOP_CONFIG"' > /run.sh && \
+RUN echo '#!/bin/bash\nset -e\nexec "$@" "$NTOP_CONFIG"' > /run.sh && \
     chmod +x /run.sh
 
 ENTRYPOINT ["/run.sh"]

--- a/Dockerfile.pfring
+++ b/Dockerfile.pfring
@@ -10,7 +10,7 @@ RUN apt-get update && \
 RUN apt-get update && \
     apt-get -y install pfring
 
-RUN echo '#!/bin/bash\nset -e\nexec "$@"' > /run.sh && \
+RUN echo '#!/bin/bash\nset -e\nexec "$@ $NTOP_CONFIG"' > /run.sh && \
     chmod +x /run.sh
 
 ENTRYPOINT ["/run.sh"]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains configuration files used to generate Docker images regi
 ## Prerequisites
 
 In order to use the PF_RING tools or take advantage of the PF_RING acceleration when using the ntop
-applications, the PF_RING kernel module and drivers need to be loaded on the host system. Please 
+applications, the PF_RING kernel module and drivers need to be loaded on the host system. Please
 read the instructions in the [PF_RING User's Guide](http://www.ntop.org/guides/pf_ring/get_started/index.html)
 and [Using PF_RING with Docker](https://www.ntop.org/guides/pf_ring/containers/docker.html)
 
@@ -17,15 +17,15 @@ To troubleshoot issued
 
 ## Install and Run
 
-```
+```bash
 docker build -t pfring -f Dockerfile.pfring .
 docker run --net=host pfring pfcount -i eno1
 ```
 
-If you want to use a ZC interface, you need to access the license file from the container, 
+If you want to use a ZC interface, you need to access the license file from the container,
 you can use the -v|--volume option for this:
 
-```
+```bash
 docker run --net=host -v 001122334455:/etc/pf_ring/001122334455 pfring pfcount -i zc:eth1
 ```
 
@@ -35,7 +35,7 @@ For additional info please read the [PF_RING User's Guide](http://www.ntop.org/g
 
 ## Install and Run
 
-```
+```bash
 docker build -t ntopng -f Dockerfile.ntopng .
 docker run -it --net=host ntopng -i eno1
 ```
@@ -44,7 +44,7 @@ docker run -it --net=host ntopng -i eno1
 
 ## Install and Run
 
-```
+```bash
 docker build -t nprobe -f Dockerfile.nprobe .
 docker run -it --net=host nprobe -i eno1
 ```
@@ -53,7 +53,7 @@ docker run -it --net=host nprobe -i eno1
 
 ## Install and Run
 
-```
+```bash
 docker build -t cento -f Dockerfile.cento .
 docker run -it --net=host cento -i eno1
 ```
@@ -62,7 +62,7 @@ docker run -it --net=host cento -i eno1
 
 ## Install and Run
 
-```
+```bash
 docker build -t agent -f Dockerfile.agent .
 docker run -it --network=host -v /etc/nprobe-agent.license:/etc/nprobe-agent.license:ro -v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro -v /etc/localtime:/etc/localtime:ro -v /sys/kernel/debug:/sys/kernel/debug -v /var/run/docker.sock:/var/run/docker.sock -v /snap/bin/microk8s.ctr:/snap/bin/microk8s.ctr agent
 ```
@@ -71,7 +71,7 @@ docker run -it --network=host -v /etc/nprobe-agent.license:/etc/nprobe-agent.lic
 
 ## Install and Run
 
-```
+```bash
 docker build -t n2disk -f Dockerfile.n2disk .
 docker run -it --cap-add IPC_LOCK --net=host n2disk -i eno1 -o /tmp
 ```
@@ -82,15 +82,22 @@ Note: IPC_LOCK is required to use the Direct IO support in n2disk, which require
 
 ## Install and Run
 
-```
+```bash
 docker build -t nscrub -f Dockerfile.nscrub .
 docker run -it --net=host nscrub -i eth1 -o eth2
 ```
 
-Note: you can configure the application license sharing the license file with the container, 
+Note: you can configure the application license sharing the license file with the container,
 you can do this using the -v|--volume option. This applies to all the applications.
 
-```
+```bash
 docker run -it --net=host -v $(pwd)/nscrub.license:/etc/nscrub.license nscrub -i eth1 -o eth2
 ```
 
+# `NTOP_CONFIG` environment variable
+
+You can pass configuration options also via the `NTOP_CONFIG` environment variable, using the `-e` option. This applies to all the applications.
+
+```bash
+docker run -it -e NTOP_CONFIG="-i eno1" --net=host ntopng
+```


### PR DESCRIPTION
- sometimes it is not possible/desirable to pass command arguments to `docker run`
- with this PR, config options can (also) be passed as env variable `NTOP_CONFIG`
- e.g. something like `docker run -it -e NTOP_CONFIG="-i eno1" --net=host ntopng` becomes possible
- the PR implements this for all Dockerfiles in the repo