### PR TITLE
Allow multiple config options via the environment variable

### DIFF
--- a/Dockerfile.cento
+++ b/Dockerfile.cento
@@ -10,7 +10,7 @@ RUN apt-get update && \
 RUN apt-get update && \
     apt-get -y install cento
 
-RUN echo '#!/bin/bash\ncento "$@" "$NTOP_CONFIG"' > /run.sh && \
+RUN echo '#!/bin/bash\ncento "$@" $NTOP_CONFIG' > /run.sh && \
     chmod +x /run.sh
 
 ENTRYPOINT ["/run.sh"]

--- a/Dockerfile.n2disk
+++ b/Dockerfile.n2disk
@@ -10,7 +10,7 @@ RUN apt-get update && \
 RUN apt-get update && \
     apt-get -y install n2disk 
 
-RUN echo '#!/bin/bash\nn2disk "$@" "$NTOP_CONFIG"' > /run.sh && \
+RUN echo '#!/bin/bash\nn2disk "$@" $NTOP_CONFIG' > /run.sh && \
     chmod +x /run.sh
 
 ENTRYPOINT ["/run.sh"]

--- a/Dockerfile.nprobe
+++ b/Dockerfile.nprobe
@@ -10,7 +10,7 @@ RUN apt-get update && \
 RUN apt-get update && \
     apt-get -y install nprobe
 
-RUN echo '#!/bin/bash\nnprobe "$@" "$NTOP_CONFIG"' > /run.sh && \
+RUN echo '#!/bin/bash\nnprobe "$@" $NTOP_CONFIG' > /run.sh && \
     chmod +x /run.sh
 
 ENTRYPOINT ["/run.sh"]

--- a/Dockerfile.nprobe.dev
+++ b/Dockerfile.nprobe.dev
@@ -10,7 +10,7 @@ RUN apt-get update && \
 RUN apt-get update && \
     apt-get -y install nprobe
 
-RUN echo '#!/bin/bash\nnprobe "$@"' > /run.sh && \
+RUN echo '#!/bin/bash\nnprobe "$@" $NTOP_CONFIG' > /run.sh && \
     chmod +x /run.sh
 
 ENTRYPOINT ["/run.sh"]

--- a/Dockerfile.nscrub
+++ b/Dockerfile.nscrub
@@ -10,7 +10,7 @@ RUN apt-get update && \
 RUN apt-get update && \
     apt-get -y install nscrub 
 
-RUN echo '#!/bin/bash\nnscrub "$@" "$NTOP_CONFIG"' > /run.sh && \
+RUN echo '#!/bin/bash\nnscrub "$@" $NTOP_CONFIG' > /run.sh && \
     chmod +x /run.sh
 
 EXPOSE 8880

--- a/Dockerfile.ntopng
+++ b/Dockerfile.ntopng
@@ -14,7 +14,7 @@ RUN apt-get update && \
     echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
     apt-get -y install ntopng ntopng-data
 
-RUN echo '#!/bin/bash\n/etc/init.d/redis-server start\nntopng "$@" "$NTOP_CONFIG"' > /run.sh && \
+RUN echo '#!/bin/bash\n/etc/init.d/redis-server start\nntopng "$@" $NTOP_CONFIG' > /run.sh && \
     chmod +x /run.sh
 
 EXPOSE 3000

--- a/Dockerfile.ntopng-arm64
+++ b/Dockerfile.ntopng-arm64
@@ -14,7 +14,7 @@ RUN apt-get clean all && \
     apt-get -y -q install ntopng:armhf libcap2:armhf libzstd1:armhf
     
 
-RUN echo '#!/bin/bash\n/etc/init.d/redis-server start\nntopng "$@" "$NTOP_CONFIG"' > /run.sh && \
+RUN echo '#!/bin/bash\n/etc/init.d/redis-server start\nntopng "$@" $NTOP_CONFIG' > /run.sh && \
     chmod +x /run.sh
 
 EXPOSE 3000

--- a/Dockerfile.ntopng.dev
+++ b/Dockerfile.ntopng.dev
@@ -11,7 +11,7 @@ RUN apt-get update && \
     echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
     apt-get -y install ntopng ntopng-data
 
-RUN echo '#!/bin/bash\n/etc/init.d/redis-server start\nntopng "$@" "$NTOP_CONFIG"' > /run.sh && \
+RUN echo '#!/bin/bash\n/etc/init.d/redis-server start\nntopng "$@" $NTOP_CONFIG' > /run.sh && \
     chmod +x /run.sh
 
 EXPOSE 3000

--- a/Dockerfile.pfring
+++ b/Dockerfile.pfring
@@ -10,7 +10,7 @@ RUN apt-get update && \
 RUN apt-get update && \
     apt-get -y install pfring
 
-RUN echo '#!/bin/bash\nset -e\nexec "$@" "$NTOP_CONFIG"' > /run.sh && \
+RUN echo '#!/bin/bash\nset -e\nexec "$@" $NTOP_CONFIG' > /run.sh && \
     chmod +x /run.sh
 
 ENTRYPOINT ["/run.sh"]


### PR DESCRIPTION
At the moment you can only specify one option via the environment variable because is quoted.

Unquote the variable allows more stuff to be passed in.