### PR TITLE
remove version from dockerfile, which is causing an 'obsolete' warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ A sample configuration file for running ntopng and ClickHouse is also available 
 
 Example `compose.yml` file:
 ```
-version: "3.9"
 services:
   nprobe_collector:
     image: ntop/nprobe:stable

--- a/compose/ntopng/docker-compose.yml
+++ b/compose/ntopng/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   ntopng:
     image: ntop/ntopng:stable


### PR DESCRIPTION
remove version from dockerfile, which is causing an 'obsolete' warning

The warning that this removes is:

> WARN[0000] ./ntopng/docker-compose.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 

FYI:
> # docker --version
> Docker version 20.10.24+dfsg1, build 297e128